### PR TITLE
feat: hero section with language selection (fixes #5)

### DIFF
--- a/frontend/src/__tests__/hero.test.js
+++ b/frontend/src/__tests__/hero.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { renderHero, languages } from '../components/hero.js';
+
+describe('renderHero', () => {
+  it('should render the heading with emphasized language', () => {
+    const html = renderHero();
+    expect(html).toContain('<em>language</em>');
+    expect(html).toContain('Which');
+    expect(html).toContain('do you want to learn?');
+  });
+
+  it('should render all language options', () => {
+    const html = renderHero();
+    languages.forEach(lang => {
+      expect(html).toContain(lang.name);
+    });
+  });
+
+  it('should include the hero image', () => {
+    const html = renderHero();
+    expect(html).toContain('hero_image.jpg');
+  });
+
+  it('should include the subscription banner', () => {
+    const html = renderHero();
+    expect(html).toContain('Over 25 million subscriptions sold!');
+  });
+});
+
+describe('languages data', () => {
+  it('should have 6 language options', () => {
+    expect(languages).toHaveLength(6);
+  });
+});

--- a/frontend/src/components/hero.js
+++ b/frontend/src/components/hero.js
@@ -1,0 +1,58 @@
+/**
+ * Language data for the selection grid.
+ */
+export const languages = [
+  { name: 'Spanish (Mexico)', flag: '🇲🇽', slug: 'QMS' },
+  { name: 'Spanish (Spain)', flag: '🇪🇸', slug: 'SPA' },
+  { name: 'French', flag: '🇫🇷', slug: 'FRA' },
+  { name: 'German', flag: '🇩🇪', slug: 'DEU' },
+  { name: 'Italian', flag: '🇮🇹', slug: 'ITA' },
+  { name: 'More', flag: '🌐', slug: '' },
+];
+
+/**
+ * Renders a single language button.
+ * @param {{ name: string, flag: string, slug: string }} lang
+ * @returns {string}
+ */
+function renderLanguageButton(lang) {
+  const href = lang.slug
+    ? `https://my.babbel.com/en/onboarding/default?learn_lang=${lang.slug}`
+    : 'https://my.babbel.com/en/onboarding/default';
+  return `
+    <li class="hero__lang-item">
+      <a href="${href}" class="hero__lang-link">
+        <span class="hero__lang-flag">${lang.flag}</span>
+        <span class="hero__lang-name">${lang.name}</span>
+      </a>
+    </li>
+  `;
+}
+
+/**
+ * Renders the hero section.
+ * @returns {string}
+ */
+export function renderHero() {
+  const langButtons = languages.map(renderLanguageButton).join('');
+  return `
+    <section class="hero">
+      <div class="hero__content">
+        <div class="hero__text">
+          <h1 class="hero__title">Which <em>language</em> do you want to learn?</h1>
+          <ul class="hero__lang-grid">
+            ${langButtons}
+          </ul>
+        </div>
+        <div class="hero__image-wrapper">
+          <img src="/assets/hero_image.jpg"
+               alt="A diverse group of people engaged in a relaxed conversation while sitting around a table in a garden."
+               class="hero__image" />
+        </div>
+      </div>
+      <div class="hero__banner">
+        <span class="hero__banner-text">Over 25 million subscriptions sold!</span>
+      </div>
+    </section>
+  `;
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 import './style.css';
 import { renderHeader, initHeader } from './components/header.js';
+import { renderHero } from './components/hero.js';
 
 /**
  * Initialize the Babbel mock application.
@@ -10,9 +11,7 @@ export function initApp() {
   app.innerHTML = `
     ${renderHeader()}
     <main id="main">
-      <p style="padding: 120px 40px; text-align: center; font-size: 1.2rem;">
-        More sections coming soon...
-      </p>
+      ${renderHero()}
     </main>
   `;
   initHeader();

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -135,3 +135,103 @@ body {
 .header__signup-btn:hover {
   opacity: 0.9;
 }
+
+/* ===== HERO ===== */
+.hero {
+  margin-top: 64px;
+  background: var(--color-white);
+}
+
+.hero__content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 24px 0;
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
+.hero__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.hero__title {
+  font-size: 42px;
+  font-weight: 800;
+  line-height: 1.15;
+  margin-bottom: 32px;
+  color: var(--color-text);
+}
+
+.hero__title em {
+  font-style: italic;
+  color: var(--color-primary);
+}
+
+.hero__lang-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.hero__lang-item {
+  display: block;
+}
+
+.hero__lang-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 12px;
+  text-decoration: none;
+  color: var(--color-text);
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.hero__lang-link:hover {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
+.hero__lang-flag {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.hero__lang-name {
+  white-space: nowrap;
+}
+
+.hero__image-wrapper {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.hero__image {
+  width: 100%;
+  max-width: 500px;
+  height: auto;
+  border-radius: 16px;
+  object-fit: cover;
+}
+
+.hero__banner {
+  background: var(--color-accent-gold);
+  text-align: center;
+  padding: 14px 24px;
+  margin-top: 32px;
+}
+
+.hero__banner-text {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text);
+}


### PR DESCRIPTION
Closes #5
- Hero section with heading, language grid, hero image, gold banner
- 5 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)